### PR TITLE
Feature/extended members

### DIFF
--- a/classes.h
+++ b/classes.h
@@ -40,6 +40,7 @@ enum CSWeaponType
 };
 
 class CEconItemView;
+class CEconItemDefinition;
 
 class CCSWeaponData
 {
@@ -64,6 +65,7 @@ public:
 
     // Integers
     uint16 ItemDef() const                                   { return m_nDefIndex; }
+    CEconItemDefinition* Definition() const                   { return m_pDefinition; }
     int MaxClip1() const 									 { return m_iMaxClip1; }
     int MaxClip2() const 									 { return m_iMaxClip2; }
     int DefaultClip1() const 								 { return m_iDefaultClip1; }
@@ -90,6 +92,7 @@ public:
 
     // Setters
     void SetItemDef(int value)                               { m_nDefIndex = value; }
+    void SetDefinition(CEconItemDefinition* value)            { m_pDefinition = value; }
     void SetMaxClip1(int value) 							 { m_iMaxClip1 = value; }
     void SetMaxClip2(int value) 							 { m_iMaxClip2 = value; }
     void SetDefaultClip1(int value) 						 { m_iDefaultClip1 = value; }
@@ -252,7 +255,7 @@ public:
     void SetWorldModel(char* source)               			{ m_szWorldModel = source; }
     void SetDroppedModel(char* source)             			{ m_szDroppedModel = source; }
     void SetShotSound(char* source)				   			{ m_szShotSound = source; }
-       void SetEmptySound(char* source)				   		{ m_szEmptySound = source; }
+    void SetEmptySound(char* source)				   		{ m_szEmptySound = source; }
     void SetBulletType(char* source)				   		{ m_szBulletType = source; }
     void SetHudName(char* source)             				{ m_szHudName = source; }
     void SetDefaultName(char* source)				   		{ m_szDefaultName = source; }
@@ -270,7 +273,8 @@ private:
     void* m_pVTable;                        // 0 [4]
     char* m_szClassName;                  	// 4 [4]
     uint16 m_nDefIndex;                     // 8 [2]
-    char padding[10];                       // 10 [10]
+    char padding[6];                        // 10 [6]
+    CEconItemDefinition* m_pDefinition;     // 16 [4]
     int m_iMaxClip1;                        // 20 [4]
     int m_iMaxClip2;                        // 24 [4]
     int m_iDefaultClip1;                    // 28 [4]

--- a/classes.h
+++ b/classes.h
@@ -109,6 +109,7 @@ public:
     int ZoomFov2() const 									 { return m_iZoomFov2; }
     int TracerFrequency() const 							 { return m_iTracerFrequency; }
     int TracerFrequencyAlt() const 							 { return m_iTracerFrequencyAlt; }
+    int UsedByTeam() const                                   { return m_nUsedByTeam; }
 
     CSWeaponType WeaponType() const 						 { return m_iWeaponType; }
     CSBotDifficultyType BotDifficultyType() const            { return m_BotDifficultyType; }
@@ -140,6 +141,7 @@ public:
     void SetZoomFov2(int value) 							 { m_iZoomFov2 = value; }
     void SetTracerFrequency(int value) 						 { m_iTracerFrequency = value; }
     void SetTracerFrequencyAlt(int value) 					 { m_iTracerFrequencyAlt = value; }
+    void SetUsedByTeam(int value)                            { m_nUsedByTeam = value; }
 
     void SetWeaponType(CSWeaponType value)					 { m_iWeaponType = value; }
     void SetBotDifficultyType(CSBotDifficultyType value)	 { m_BotDifficultyType = value; }
@@ -339,7 +341,7 @@ private:
     float m_flTimeToIdle;                   // 228 [4]
     float m_flIdleInterval;                 // 232 [4]
     bool m_bFullAuto;                       // 236 [1]
-    char padding_9[3];                      // 237 [3]
+    char padding_8[3];                      // 237 [3]
     int m_iDamage;                          // 240 [4]
     float m_flHeadshotMultiplier;			// 244 [4]
     float m_flArmorRatio;                   // 248 [4]
@@ -350,9 +352,9 @@ private:
     float m_flRange;                        // 268 [4]
     float m_flRangeModifier;                // 272 [4]
     float m_flThrowVelocity;                // 276 [4]
-    char padding_10[12];                    // 280 [12]
+    char padding_9[12];                     // 280 [12]
     bool m_bHasSilencer;                    // 292 [1]
-    char padding_11[3];                     // 293 [3]
+    char padding_10[3];                     // 293 [3]
     char* m_pSilencerModel;                 // 296 [4]
     int m_iCrosshairMinDistance;            // 300 [4]
     int m_iCrosshairDeltaDistance;          // 304 [4]
@@ -396,7 +398,7 @@ private:
     int m_iRecoveryTransitionEndBullet;	    // 456 [4]
     bool m_bUnzoomAfterShot;				// 460 [1]
     bool m_bHideViewModelZoomed;			// 461 [1]
-    char padding_12[2];					    // 462 [2]
+    char padding_11[2];					    // 462 [2]
     int m_iZoomLevels;					    // 464 [4]
     int m_iZoomFov1;						// 468 [4]
     int m_iZoomFov2;						// 472 [4]
@@ -404,16 +406,16 @@ private:
     float m_flZoomTime1;					// 480 [4]
     float m_flZoomTime2;					// 484 [4]
     char* m_szAddonlocation;                // 488 [4]
-    char padding_13[4];					    // 492 [4]
+    char padding_12[4];					    // 492 [4]
     float m_flAddonScale;					// 496 [4]
     char* m_szEjectBrassEffect;             // 500 [4]
     char* m_szTracerEffect;                 // 504 [4]
     int m_iTracerFrequency;                 // 508 [4]
     int m_iTracerFrequencyAlt;              // 512 [4]
     char* m_szMuzzleFlashEffect1stPerson;   // 516 [4]
-    char padding_14[4];                     // 520 [4]
+    char padding_13[4];                     // 520 [4]
     char* m_szMuzzleFlashEffect3stPerson;   // 524 [4]
-    char padding_15[4];                     // 528 [4]
+    char padding_14[4];                     // 528 [4]
     char* m_szHeatEffect;            		// 532 [4]
     float m_flHeatPerShot;                  // 536 [4]
     char* m_szZoomInSound;                  // 540 [4]
@@ -421,7 +423,9 @@ private:
     float m_flInaccuracyPitchShift;         // 548 [4]
     float m_flInaccuracySoundThreshold;     // 552 [4]
     float m_flBotAudibleRange;              // 556 [4]
-    char padding_16[12];                    // 560 [12]
+    char padding_15[4];                     // 560 [4]
+    int m_nUsedByTeam;                      // 564 [4]
+    char padding_16[4];                     // 568 [4]
     bool m_bHasBurstMode;                   // 572 [1]
     bool m_bIsRevolver;                     // 573 [1]
     bool m_bCannotShootUnderwater;		    // 574 [1]

--- a/classes.h
+++ b/classes.h
@@ -39,6 +39,19 @@ enum CSWeaponType
     WEAPONTYPE_UNKNOWN
 };
 
+/**
+ * 'CCSWeaponData::BotDifficultyType' values.
+ */
+enum CSBotDifficultyType
+{
+	BOT_EASY = 0,
+	BOT_NORMAL = 1,
+	BOT_HARD = 2,
+	BOT_EXPERT = 3,
+
+	NUM_DIFFICULTY_LEVELS
+};
+
 class CEconItemView;
 class CEconItemDefinition;
 
@@ -46,6 +59,9 @@ class CCSWeaponData
 {
 public:
     // Booleans
+    bool AllowHandFlipping() const                           { return m_bAllowHandFlipping; }
+    bool ModelRightHanded() const                            { return m_bModelRightHanded; }
+    bool IsMeleeWeapon() const                               { return m_bIsMeleeWeapon; }
     bool HasSilencer() const                                 { return m_bHasSilencer; }
     bool FullAuto() const                                  	 { return m_bFullAuto; }
     bool ShouldUnzoomAfterShot() const                       { return m_bUnzoomAfterShot; }
@@ -55,6 +71,9 @@ public:
     bool CannotShootUnderwater() const                       { return m_bCannotShootUnderwater; }
 
     // Setters
+    void SetAllowHandFlipping(bool value)              	     { m_bAllowHandFlipping = value; }
+    void SetModelRightHanded(bool value)              	     { m_bModelRightHanded = value; }
+    void SetIsMeleeWeapon(bool value)              	         { m_bIsMeleeWeapon = value; }
     void SetHasSilencer(bool value)              	    	 { m_bHasSilencer = value; }
     void SetFullAuto(bool value)              	    	 	 { m_bFullAuto = value; }
     void SetShouldUnzoomAfterShot(bool value)              	 { m_bUnzoomAfterShot = value; }
@@ -65,13 +84,16 @@ public:
 
     // Integers
     uint16 ItemDef() const                                   { return m_nDefIndex; }
-    CEconItemDefinition* Definition() const                   { return m_pDefinition; }
+    CEconItemDefinition* Definition() const                  { return m_pDefinition; }
     int MaxClip1() const 									 { return m_iMaxClip1; }
     int MaxClip2() const 									 { return m_iMaxClip2; }
     int DefaultClip1() const 								 { return m_iDefaultClip1; }
     int DefaultClip2() const 								 { return m_iDefaultClip2; }
     int PrimaryReserveAmmoMax() const 						 { return m_iPrimaryReserveAmmoMax; }
     int SecondaryReserveAmmoMax() const 					 { return m_iSecondaryReserveAmmoMax; }
+    int ItemFlags() const                                    { return m_iItemFlags; }
+    int Weight() const                                       { return m_iWeight; }
+    int RumbleEffect() const                                 { return m_iRumbleEffect; }
     int WeaponPrice() const 								 { return m_iWeaponPrice; }
     int KillAward() const 									 { return m_iKillAward; }
     int Damage() const 										 { return m_iDamage; }
@@ -89,16 +111,20 @@ public:
     int TracerFrequencyAlt() const 							 { return m_iTracerFrequencyAlt; }
 
     CSWeaponType WeaponType() const 						 { return m_iWeaponType; }
+    CSBotDifficultyType BotDifficultyType() const            { return m_BotDifficultyType; }
 
     // Setters
     void SetItemDef(int value)                               { m_nDefIndex = value; }
-    void SetDefinition(CEconItemDefinition* value)            { m_pDefinition = value; }
+    void SetDefinition(CEconItemDefinition* value)           { m_pDefinition = value; }
     void SetMaxClip1(int value) 							 { m_iMaxClip1 = value; }
     void SetMaxClip2(int value) 							 { m_iMaxClip2 = value; }
     void SetDefaultClip1(int value) 						 { m_iDefaultClip1 = value; }
     void SetDefaultClip2(int value) 						 { m_iDefaultClip2 = value; }
     void SetPrimaryReserveAmmoMax(int value) 				 { m_iPrimaryReserveAmmoMax = value; }
     void SetSecondaryReserveAmmoMax(int value) 				 { m_iSecondaryReserveAmmoMax = value; }
+    void SetItemFlags(int value)                             { m_iItemFlags = value; }
+    void SetWeight(int value)                                { m_iWeight = value; }
+    void SetRumbleEffect(int value)                          { m_iRumbleEffect = value; }
     void SetWeaponPrice(int value) 							 { m_iWeaponPrice = value; }
     void SetKillAward(int value) 							 { m_iKillAward = value; }
     void SetDamage(int value) 							 	 { m_iDamage = value; }
@@ -115,7 +141,8 @@ public:
     void SetTracerFrequency(int value) 						 { m_iTracerFrequency = value; }
     void SetTracerFrequencyAlt(int value) 					 { m_iTracerFrequencyAlt = value; }
 
-    void SetWeaponType(CSWeaponType value)					  { m_iWeaponType = value; }
+    void SetWeaponType(CSWeaponType value)					 { m_iWeaponType = value; }
+    void SetBotDifficultyType(CSBotDifficultyType value)	 { m_BotDifficultyType = value; }
 
     // Floats
     float CycleTime() const                                 { return m_flCycleTime; }
@@ -293,9 +320,17 @@ private:
     char padding_4[4];                      // 132 [4]
     char* m_szHudName;                      // 136 [4]
     char* m_szDefaultName;                  // 140 [4]
-    char padding_5[56];                     // 144 [56]
+    bool m_bAllowHandFlipping;              // 144 [1]
+    bool m_bModelRightHanded;               // 145 [1]
+    bool m_bIsMeleeWeapon;                  // 146 [1]
+    char padding_5[5];                      // 147 [5]
+    int m_iItemFlags;                       // 152 [4]
+    int m_iWeight;                          // 156 [4]
+    char padding_6[32];                     // 160 [32]
+    int m_iRumbleEffect;                    // 192 [4]
+    char padding_7[4];                      // 196 [4]
     CSWeaponType m_iWeaponType;             // 200 [4]
-    char padding_6[4];                      // 204 [4]
+    CSBotDifficultyType m_BotDifficultyType;// 204 [4]
     int m_iWeaponPrice;                     // 208 [4]
     int m_iKillAward;                       // 212 [4]
     char* m_szAnimationPrefix;              // 216 [4]
@@ -304,7 +339,7 @@ private:
     float m_flTimeToIdle;                   // 228 [4]
     float m_flIdleInterval;                 // 232 [4]
     bool m_bFullAuto;                       // 236 [1]
-    char padding_7[3];                      // 237 [3]
+    char padding_9[3];                      // 237 [3]
     int m_iDamage;                          // 240 [4]
     float m_flHeadshotMultiplier;			// 244 [4]
     float m_flArmorRatio;                   // 248 [4]
@@ -315,9 +350,9 @@ private:
     float m_flRange;                        // 268 [4]
     float m_flRangeModifier;                // 272 [4]
     float m_flThrowVelocity;                // 276 [4]
-    char padding_8[12];                     // 280 [12]
+    char padding_10[12];                    // 280 [12]
     bool m_bHasSilencer;                    // 292 [1]
-    char padding_9[3];                      // 293 [3]
+    char padding_11[3];                     // 293 [3]
     char* m_pSilencerModel;                 // 296 [4]
     int m_iCrosshairMinDistance;            // 300 [4]
     int m_iCrosshairDeltaDistance;          // 304 [4]
@@ -361,7 +396,7 @@ private:
     int m_iRecoveryTransitionEndBullet;	    // 456 [4]
     bool m_bUnzoomAfterShot;				// 460 [1]
     bool m_bHideViewModelZoomed;			// 461 [1]
-    char padding_10[2];					    // 462 [2]
+    char padding_12[2];					    // 462 [2]
     int m_iZoomLevels;					    // 464 [4]
     int m_iZoomFov1;						// 468 [4]
     int m_iZoomFov2;						// 472 [4]
@@ -369,16 +404,16 @@ private:
     float m_flZoomTime1;					// 480 [4]
     float m_flZoomTime2;					// 484 [4]
     char* m_szAddonlocation;                // 488 [4]
-    char padding_11[4];					    // 492 [4]
+    char padding_13[4];					    // 492 [4]
     float m_flAddonScale;					// 496 [4]
     char* m_szEjectBrassEffect;             // 500 [4]
     char* m_szTracerEffect;                 // 504 [4]
     int m_iTracerFrequency;                 // 508 [4]
     int m_iTracerFrequencyAlt;              // 512 [4]
     char* m_szMuzzleFlashEffect1stPerson;   // 516 [4]
-    char padding_12[4];                     // 520 [4]
+    char padding_14[4];                     // 520 [4]
     char* m_szMuzzleFlashEffect3stPerson;   // 524 [4]
-    char padding_13[4];                     // 528 [4]
+    char padding_15[4];                     // 528 [4]
     char* m_szHeatEffect;            		// 532 [4]
     float m_flHeatPerShot;                  // 536 [4]
     char* m_szZoomInSound;                  // 540 [4]
@@ -386,7 +421,7 @@ private:
     float m_flInaccuracyPitchShift;         // 548 [4]
     float m_flInaccuracySoundThreshold;     // 552 [4]
     float m_flBotAudibleRange;              // 556 [4]
-    char padding_14[12];                    // 560 [12]
+    char padding_16[12];                    // 560 [12]
     bool m_bHasBurstMode;                   // 572 [1]
     bool m_bIsRevolver;                     // 573 [1]
     bool m_bCannotShootUnderwater;		    // 574 [1]

--- a/classes.h
+++ b/classes.h
@@ -63,6 +63,7 @@ public:
     void SetCannotShootUnderwater(bool value)              	 { m_bCannotShootUnderwater = value; }
 
     // Integers
+    uint16 ItemDef() const                                   { return m_nDefIndex; }
     int MaxClip1() const 									 { return m_iMaxClip1; }
     int MaxClip2() const 									 { return m_iMaxClip2; }
     int DefaultClip1() const 								 { return m_iDefaultClip1; }
@@ -88,6 +89,7 @@ public:
     CSWeaponType WeaponType() const 						 { return m_iWeaponType; }
 
     // Setters
+    void SetItemDef(int value)                               { m_nDefIndex = value; }
     void SetMaxClip1(int value) 							 { m_iMaxClip1 = value; }
     void SetMaxClip2(int value) 							 { m_iMaxClip2 = value; }
     void SetDefaultClip1(int value) 						 { m_iDefaultClip1 = value; }
@@ -267,7 +269,8 @@ public:
 private:
     void* m_pVTable;                        // 0 [4]
     char* m_szClassName;                  	// 4 [4]
-    char padding[12];                       // 8 [12]
+    uint16 m_nDefIndex;                     // 8 [2]
+    char padding[10];                       // 10 [10]
     int m_iMaxClip1;                        // 20 [4]
     int m_iMaxClip2;                        // 24 [4]
     int m_iDefaultClip1;                    // 28 [4]

--- a/natives.cpp
+++ b/natives.cpp
@@ -789,6 +789,26 @@ static cell_t CSWeaponData_SetTracerFrequencyAlt(IPluginContext* pContext, const
     return 1;
 }
 
+static cell_t CSWeaponData_GetUsedByTeam(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->UsedByTeam();
+}
+
+static cell_t CSWeaponData_SetUsedByTeam(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetUsedByTeam(params[2]);
+
+    return 1;
+}
+
 static cell_t CSWeaponData_GetWeaponType(IPluginContext* pContext, const cell_t* params)
 {
     CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
@@ -2479,6 +2499,8 @@ extern const sp_nativeinfo_t g_MyNatives[] =
     { "CSWeaponData.TracerFrequency.set",                   CSWeaponData_SetTracerFrequency },
     { "CSWeaponData.TracerFrequencyAlt.get",                CSWeaponData_GetTracerFrequencyAlt },
     { "CSWeaponData.TracerFrequencyAlt.set",                CSWeaponData_SetTracerFrequencyAlt },
+    { "CSWeaponData.UsedByTeam.get",                        CSWeaponData_GetUsedByTeam },
+    { "CSWeaponData.UsedByTeam.set",                        CSWeaponData_SetUsedByTeam },
     { "CSWeaponData.WeaponType.get",                        CSWeaponData_GetWeaponType },
     { "CSWeaponData.WeaponType.set",                        CSWeaponData_SetWeaponType },
     { "CSWeaponData.BotDifficultyType.get",                 CSWeaponData_GetBotDifficultyType },

--- a/natives.cpp
+++ b/natives.cpp
@@ -209,6 +209,26 @@ static cell_t CSWeaponData_SetCannotShootUnderwater(IPluginContext* pContext, co
     return 1;
 }
 
+static cell_t CSWeaponData_GetItemDef(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->ItemDef();
+}
+
+static cell_t CSWeaponData_SetItemDef(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetItemDef(params[2]);
+
+    return 1;
+}
+
 static cell_t CSWeaponData_GetMaxClip1(IPluginContext* pContext, const cell_t* params)
 {
     CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
@@ -2240,6 +2260,8 @@ extern const sp_nativeinfo_t g_MyNatives[] =
     { "CSWeaponData.CannotShootUnderwater.get",             CSWeaponData_GetCannotShootUnderwater },
     { "CSWeaponData.CannotShootUnderwater.set",             CSWeaponData_SetCannotShootUnderwater },
 
+    { "CSWeaponData.ItemDef.get",                           CSWeaponData_GetItemDef },
+    { "CSWeaponData.ItemDef.set",                           CSWeaponData_SetItemDef },
     { "CSWeaponData.MaxClip1.get",                          CSWeaponData_GetMaxClip1 },
     { "CSWeaponData.MaxClip1.set",                          CSWeaponData_SetMaxClip1 },
     { "CSWeaponData.MaxClip2.get",                          CSWeaponData_GetMaxClip2 },

--- a/natives.cpp
+++ b/natives.cpp
@@ -69,6 +69,66 @@ static cell_t CSWeaponData_Size(IPluginContext* pContext, const cell_t* params)
     return sizeof(CCSWeaponData);
 }
 
+static cell_t CSWeaponData_GetAllowHandFlipping(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->AllowHandFlipping();
+}
+
+static cell_t CSWeaponData_SetAllowHandFlipping(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetAllowHandFlipping(params[2]);
+
+    return 1;
+}
+
+static cell_t CSWeaponData_GetModelRightHanded(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->ModelRightHanded();
+}
+
+static cell_t CSWeaponData_SetModelRightHanded(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetModelRightHanded(params[2]);
+
+    return 1;
+}
+
+static cell_t CSWeaponData_GetIsMeleeWeapon(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->IsMeleeWeapon();
+}
+
+static cell_t CSWeaponData_SetIsMeleeWeapon(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetIsMeleeWeapon(params[2]);
+
+    return 1;
+}
+
 static cell_t CSWeaponData_GetHasSilencer(IPluginContext* pContext, const cell_t* params)
 {
     CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
@@ -365,6 +425,66 @@ static cell_t CSWeaponData_SetSecondaryReserveAmmoMax(IPluginContext* pContext, 
     SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
 
     pCCSWeaponData->SetSecondaryReserveAmmoMax(params[2]);
+
+    return 1;
+}
+
+static cell_t CSWeaponData_GetItemFlags(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->ItemFlags();
+}
+
+static cell_t CSWeaponData_SetItemFlags(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetItemFlags(params[2]);
+
+    return 1;
+}
+
+static cell_t CSWeaponData_GetWeight(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->Weight();
+}
+
+static cell_t CSWeaponData_SetWeight(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetWeight(params[2]);
+
+    return 1;
+}
+
+static cell_t CSWeaponData_GetRumbleEffect(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->RumbleEffect();
+}
+
+static cell_t CSWeaponData_SetRumbleEffect(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetRumbleEffect(params[2]);
 
     return 1;
 }
@@ -685,6 +805,26 @@ static cell_t CSWeaponData_SetWeaponType(IPluginContext* pContext, const cell_t*
     SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
 
     pCCSWeaponData->SetWeaponType((CSWeaponType)params[2]);
+
+    return 1;
+}
+
+static cell_t CSWeaponData_GetBotDifficultyType(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return pCCSWeaponData->BotDifficultyType();
+}
+
+static cell_t CSWeaponData_SetBotDifficultyType(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetBotDifficultyType((CSBotDifficultyType)params[2]);
 
     return 1;
 }
@@ -2265,6 +2405,13 @@ extern const sp_nativeinfo_t g_MyNatives[] =
     { "CSWeaponData.GetByIndex",                            CSWeaponData_GetByIndex },
     { "CSWeaponData.Count",                                 CSWeaponData_Count },
     { "CSWeaponData.Size",                                  CSWeaponData_Size },
+
+    { "CSWeaponData.AllowHandFlipping.get",                 CSWeaponData_GetAllowHandFlipping },
+    { "CSWeaponData.AllowHandFlipping.set",                 CSWeaponData_SetAllowHandFlipping },
+    { "CSWeaponData.ModelRightHanded.get",                  CSWeaponData_GetModelRightHanded },
+    { "CSWeaponData.ModelRightHanded.set",                  CSWeaponData_SetModelRightHanded },
+    { "CSWeaponData.IsMeleeWeapon.get",                     CSWeaponData_GetIsMeleeWeapon },
+    { "CSWeaponData.IsMeleeWeapon.set",                     CSWeaponData_SetIsMeleeWeapon },
     { "CSWeaponData.HasSilencer.get",                       CSWeaponData_GetHasSilencer },
     { "CSWeaponData.HasSilencer.set",                       CSWeaponData_SetHasSilencer },
     { "CSWeaponData.FullAuto.get",                          CSWeaponData_GetFullAuto },
@@ -2296,6 +2443,12 @@ extern const sp_nativeinfo_t g_MyNatives[] =
     { "CSWeaponData.PrimaryReserveAmmoMax.set",             CSWeaponData_SetPrimaryReserveAmmoMax },
     { "CSWeaponData.SecondaryReserveAmmoMax.get",           CSWeaponData_GetSecondaryReserveAmmoMax },
     { "CSWeaponData.SecondaryReserveAmmoMax.set",           CSWeaponData_SetSecondaryReserveAmmoMax },
+    { "CSWeaponData.ItemFlags.get",                         CSWeaponData_GetItemFlags },
+    { "CSWeaponData.ItemFlags.set",                         CSWeaponData_SetItemFlags },
+    { "CSWeaponData.Weight.get",                            CSWeaponData_GetWeight },
+    { "CSWeaponData.Weight.set",                            CSWeaponData_SetWeight },
+    { "CSWeaponData.RumbleEffect.get",                      CSWeaponData_GetRumbleEffect },
+    { "CSWeaponData.RumbleEffect.set",                      CSWeaponData_SetRumbleEffect },
     { "CSWeaponData.WeaponPrice.get",                       CSWeaponData_GetWeaponPrice },
     { "CSWeaponData.WeaponPrice.set",                       CSWeaponData_SetWeaponPrice },
     { "CSWeaponData.KillAward.get",                         CSWeaponData_GetKillAward },
@@ -2328,6 +2481,8 @@ extern const sp_nativeinfo_t g_MyNatives[] =
     { "CSWeaponData.TracerFrequencyAlt.set",                CSWeaponData_SetTracerFrequencyAlt },
     { "CSWeaponData.WeaponType.get",                        CSWeaponData_GetWeaponType },
     { "CSWeaponData.WeaponType.set",                        CSWeaponData_SetWeaponType },
+    { "CSWeaponData.BotDifficultyType.get",                 CSWeaponData_GetBotDifficultyType },
+    { "CSWeaponData.BotDifficultyType.set",                 CSWeaponData_SetBotDifficultyType },
 
     { "CSWeaponData.CycleTime.get",                         CSWeaponData_GetCycleTime },
     { "CSWeaponData.CycleTime.set",                         CSWeaponData_SetCycleTime },

--- a/natives.cpp
+++ b/natives.cpp
@@ -229,6 +229,26 @@ static cell_t CSWeaponData_SetItemDef(IPluginContext* pContext, const cell_t* pa
     return 1;
 }
 
+static cell_t CSWeaponData_GetDefinition(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    return reinterpret_cast<cell_t>(pCCSWeaponData->Definition());
+}
+
+static cell_t CSWeaponData_SetDefinition(IPluginContext* pContext, const cell_t* params)
+{
+    CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
+
+    SM_NATIVE_ERROR_IF_NULL(pCCSWeaponData);
+
+    pCCSWeaponData->SetDefinition(reinterpret_cast<CEconItemDefinition*>(params[2]));
+
+    return 1;
+}
+
 static cell_t CSWeaponData_GetMaxClip1(IPluginContext* pContext, const cell_t* params)
 {
     CCSWeaponData* pCCSWeaponData = reinterpret_cast<CCSWeaponData*>(params[1]);
@@ -2262,6 +2282,8 @@ extern const sp_nativeinfo_t g_MyNatives[] =
 
     { "CSWeaponData.ItemDef.get",                           CSWeaponData_GetItemDef },
     { "CSWeaponData.ItemDef.set",                           CSWeaponData_SetItemDef },
+    { "CSWeaponData.Definition.get",                        CSWeaponData_GetDefinition },
+    { "CSWeaponData.Definition.set",                        CSWeaponData_SetDefinition },
     { "CSWeaponData.MaxClip1.get",                          CSWeaponData_GetMaxClip1 },
     { "CSWeaponData.MaxClip1.set",                          CSWeaponData_SetMaxClip1 },
     { "CSWeaponData.MaxClip2.get",                          CSWeaponData_GetMaxClip2 },

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -30,7 +30,7 @@
 #define SMEXT_CONF_VERSION		"1.0.0"
 #define SMEXT_CONF_AUTHOR		"KoNLiG"
 #define SMEXT_CONF_URL			"https://github.com/KoNLiG/CSWeaponsAPI"
-#define SMEXT_CONF_LOGTAG		"CSWeapons"
+#define SMEXT_CONF_LOGTAG		"CSWeaponsAPI"
 #define SMEXT_CONF_LICENSE		"GPL"
 #define SMEXT_CONF_DATESTRING	__DATE__
 

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -27,7 +27,7 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"CSWeaponsAPI"
 #define SMEXT_CONF_DESCRIPTION	"API for CS:GO internal weapons."
-#define SMEXT_CONF_VERSION		"1.0.0"
+#define SMEXT_CONF_VERSION		"1.10.0"
 #define SMEXT_CONF_AUTHOR		"KoNLiG"
 #define SMEXT_CONF_URL			"https://github.com/KoNLiG/CSWeaponsAPI"
 #define SMEXT_CONF_LOGTAG		"CSWeaponsAPI"

--- a/sourcemod/scripting/include/CSWeaponsAPI.inc
+++ b/sourcemod/scripting/include/CSWeaponsAPI.inc
@@ -21,6 +21,16 @@
 #endif
 #define _CSWeaponsAPI_included
 
+// 'CSWeaponData.ItemFlags' values.
+#define WEAPON_FLAG_SELECT_ON_EMPTY	(1 << 0)		// "itemflag select on empty" attribute
+#define WEAPON_FLAG_NO_AUTO_RELOAD	(1 << 1)        // "itemflag no auto reload" attribute
+#define WEAPON_FLAG_NO_AUTO_SWITCH	(1 << 2)        // "itemflag no auto switch empty" attribute
+#define WEAPON_FLAG_LIMIT_IN_WORLD	(1 << 3)        // "itemflag limit in world" attribute
+#define WEAPON_FLAG_EXHAUSTIBLE	    (1 << 4)        // "itemflag exhaustible" attribute
+#define WEAPON_FLAG_HIT_LOCATION	(1 << 5)        // "itemflag do hit location dmg" attribute
+#define WEAPON_FLAG_NO_AMMO_PICKUP	(1 << 6)        // "itemflag no ammo pickups" attribute
+#define WEAPON_FLAG_NO_ITEM_PICKUP	(1 << 7)        // "itemflag no item pickup" attribute
+
 enum CSWeaponType
 {
     WEAPONTYPE_KNIFE = 0,
@@ -35,6 +45,19 @@ enum CSWeaponType
     WEAPONTYPE_EQUIPMENT,
     WEAPONTYPE_STACKABLEITEM,
     WEAPONTYPE_UNKNOWN
+};
+
+/**
+ * 'CSWeaponData.BotDifficultyType' values.
+ */
+enum CSBotDifficultyType
+{
+	BOT_EASY = 0,
+	BOT_NORMAL = 1,
+	BOT_HARD = 2,
+	BOT_EXPERT = 3,
+
+	NUM_DIFFICULTY_LEVELS
 };
 
 // Retrieves an entity 'CEconItemView' memory address.
@@ -97,6 +120,33 @@ methodmap CSWeaponData
     //
     // @return		CCSWeaponData sizeof.
     public static native int Size();
+
+    // Retrieves whether hand flipping is allowed while using this weapon.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property bool AllowHandFlipping
+    {
+        public native get();
+        public native set(bool value);
+    }
+
+    // Retrieves whether this weapon model is explicitly a right handed model.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property bool ModelRightHanded
+    {
+        public native get();
+        public native set(bool value);
+    }
+
+    // Retrieves whether this is a melee weapon.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property bool IsMeleeWeapon
+    {
+        public native get();
+        public native set(bool value);
+    }
 
     // Retrieves whether this weapon (CSWeaponData) has a silencer.
     //
@@ -240,6 +290,34 @@ methodmap CSWeaponData
         public native set(int value);
     }
 
+    // Retrieves the weapon flags. See the defines above.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property int ItemFlags
+    {
+        public native get();
+        public native set(int value);
+    }
+
+    // Retrieves the weapon weight.
+    // This value used to determine this weapon's importance in autoselection.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property int Weight
+    {
+        public native get();
+        public native set(int value);
+    }
+
+    // Retrieves the weapon rumble effect index.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property int RumbleEffect
+    {
+        public native get();
+        public native set(int value);
+    }
+
     // Retrieves the weapon purchase price.
     //
     // @error              Invalid CSWeaponData. (null)
@@ -375,13 +453,22 @@ methodmap CSWeaponData
         public native set(int value);
     }
 
-    // Retrieves the weapon CSWeaponType value.
+    // Retrieves the weapon type. See the enum above.
     //
     // @error              Invalid CSWeaponData. (null)
     property CSWeaponType WeaponType
     {
         public native get();
         public native set(CSWeaponType value);
+    }
+
+    // Retrieves the weapon bot difficulty type. See the enum above.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property CSBotDifficultyType BotDifficultyType
+    {
+        public native get();
+        public native set(CSBotDifficultyType value);
     }
 
     // Retrieves the weapon cycle time.
@@ -1200,7 +1287,14 @@ public __ext_CSWeaponsAPI_SetNTVOptional()
     MarkNativeAsOptional("CSWeaponData.GetByClassName");
     MarkNativeAsOptional("CSWeaponData.GetByIndex");
     MarkNativeAsOptional("CSWeaponData.Count");
-    MarkNativeAsOptional("CSWeaponData.Size")
+    MarkNativeAsOptional("CSWeaponData.Size");
+
+    MarkNativeAsOptional("CSWeaponData.AllowHandFlipping.get");
+    MarkNativeAsOptional("CSWeaponData.AllowHandFlipping.set");
+    MarkNativeAsOptional("CSWeaponData.ModelRightHanded.get");
+    MarkNativeAsOptional("CSWeaponData.ModelRightHanded.set");
+    MarkNativeAsOptional("CSWeaponData.IsMeleeWeapon.get");
+    MarkNativeAsOptional("CSWeaponData.IsMeleeWeapon.set");
     MarkNativeAsOptional("CSWeaponData.HasSilencer.get");
     MarkNativeAsOptional("CSWeaponData.HasSilencer.set");
     MarkNativeAsOptional("CSWeaponData.FullAuto.get");
@@ -1232,6 +1326,12 @@ public __ext_CSWeaponsAPI_SetNTVOptional()
     MarkNativeAsOptional("CSWeaponData.PrimaryReserveAmmoMax.set");
     MarkNativeAsOptional("CSWeaponData.SecondaryReserveAmmoMax.get");
     MarkNativeAsOptional("CSWeaponData.SecondaryReserveAmmoMax.set");
+    MarkNativeAsOptional("CSWeaponData.ItemFlags.get");
+    MarkNativeAsOptional("CSWeaponData.ItemFlags.set");
+    MarkNativeAsOptional("CSWeaponData.Weight.get");
+    MarkNativeAsOptional("CSWeaponData.Weight.set");
+    MarkNativeAsOptional("CSWeaponData.RumbleEffect.get");
+    MarkNativeAsOptional("CSWeaponData.RumbleEffect.set");
     MarkNativeAsOptional("CSWeaponData.WeaponPrice.get");
     MarkNativeAsOptional("CSWeaponData.WeaponPrice.set");
     MarkNativeAsOptional("CSWeaponData.KillAward.get");
@@ -1264,6 +1364,8 @@ public __ext_CSWeaponsAPI_SetNTVOptional()
     MarkNativeAsOptional("CSWeaponData.TracerFrequencyAlt.set");
     MarkNativeAsOptional("CSWeaponData.WeaponType.get");
     MarkNativeAsOptional("CSWeaponData.WeaponType.set");
+    MarkNativeAsOptional("CSWeaponData.BotDifficultyType.get");
+    MarkNativeAsOptional("CSWeaponData.BotDifficultyType.set");
 
     MarkNativeAsOptional("CSWeaponData.CycleTime.get");
     MarkNativeAsOptional("CSWeaponData.CycleTime.set");

--- a/sourcemod/scripting/include/CSWeaponsAPI.inc
+++ b/sourcemod/scripting/include/CSWeaponsAPI.inc
@@ -168,6 +168,15 @@ methodmap CSWeaponData
         public native set(bool value);
     }
 
+    // Retrieves the weapon item definition. (m_iItemDefinitionIndex)
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property int ItemDef
+    {
+        public native get();
+        public native set(int value);
+    }
+
     // Retrieves the weapon maximum 1 clip. (m_iMaxClip1)
     //
     // @error              Invalid CSWeaponData. (null)
@@ -1198,6 +1207,8 @@ public __ext_CSWeaponsAPI_SetNTVOptional()
     MarkNativeAsOptional("CSWeaponData.CannotShootUnderwater.get");
     MarkNativeAsOptional("CSWeaponData.CannotShootUnderwater.set");
 
+    MarkNativeAsOptional("CSWeaponData.ItemDef.get");
+    MarkNativeAsOptional("CSWeaponData.ItemDef.set");
     MarkNativeAsOptional("CSWeaponData.MaxClip1.get");
     MarkNativeAsOptional("CSWeaponData.MaxClip1.set");
     MarkNativeAsOptional("CSWeaponData.MaxClip2.get");

--- a/sourcemod/scripting/include/CSWeaponsAPI.inc
+++ b/sourcemod/scripting/include/CSWeaponsAPI.inc
@@ -453,6 +453,15 @@ methodmap CSWeaponData
         public native set(int value);
     }
 
+    // Retrieves the team index (CS_TEAM...) this weapon is designated to.
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property int UsedByTeam
+    {
+        public native get();
+        public native set(int value);
+    }
+
     // Retrieves the weapon type. See the enum above.
     //
     // @error              Invalid CSWeaponData. (null)
@@ -1362,6 +1371,8 @@ public __ext_CSWeaponsAPI_SetNTVOptional()
     MarkNativeAsOptional("CSWeaponData.TracerFrequency.set");
     MarkNativeAsOptional("CSWeaponData.TracerFrequencyAlt.get");
     MarkNativeAsOptional("CSWeaponData.TracerFrequencyAlt.set");
+    MarkNativeAsOptional("CSWeaponData.UsedByTeam.get");
+    MarkNativeAsOptional("CSWeaponData.UsedByTeam.set");
     MarkNativeAsOptional("CSWeaponData.WeaponType.get");
     MarkNativeAsOptional("CSWeaponData.WeaponType.set");
     MarkNativeAsOptional("CSWeaponData.BotDifficultyType.get");

--- a/sourcemod/scripting/include/CSWeaponsAPI.inc
+++ b/sourcemod/scripting/include/CSWeaponsAPI.inc
@@ -177,6 +177,15 @@ methodmap CSWeaponData
         public native set(int value);
     }
 
+    // Retrieves the weapon item definition memory address. (CEconItemDefinition)
+    //
+    // @error              Invalid CSWeaponData. (null)
+    property Address Definition
+    {
+        public native get();
+        public native set(Address value);
+    }
+
     // Retrieves the weapon maximum 1 clip. (m_iMaxClip1)
     //
     // @error              Invalid CSWeaponData. (null)
@@ -1209,6 +1218,8 @@ public __ext_CSWeaponsAPI_SetNTVOptional()
 
     MarkNativeAsOptional("CSWeaponData.ItemDef.get");
     MarkNativeAsOptional("CSWeaponData.ItemDef.set");
+    MarkNativeAsOptional("CSWeaponData.Definition.get");
+    MarkNativeAsOptional("CSWeaponData.Definition.set");
     MarkNativeAsOptional("CSWeaponData.MaxClip1.get");
     MarkNativeAsOptional("CSWeaponData.MaxClip1.set");
     MarkNativeAsOptional("CSWeaponData.MaxClip2.get");


### PR DESCRIPTION
This update brings to the table **10** more new properties.
Most of them were discovered thanks to [Wend4r CCSWeaponData repo](https://github.com/Wend4r/CCSWeaponData/blob/master/CCSWeaponData.game.csgo.txt), much appreciated!

<h1>List of new properties</h1>

`CSWeaponData.ItemDef` - Item definition index. (**m_iItemDefinitionIndex**)
`CSWeaponData.Definition` - Item definition memory address. (**CEconItemDefinition**)
`CSWeaponData.ItemFlags` - 8 available flags with a **WEAPON_FLAG_\*** prefix, listed in `CSWeaponsAPI.inc`.
`CSWeaponData.Weight` - Used to determine importance in auto-selection.
`CSWeaponData.RumbleEffect` - XBOX only.
`CSWeaponData.BotDifficultyType` - See the enum in in `CSWeaponsAPI.inc`.
`CSWeaponData.UsedByTeam` - Designated **CS_TEAM_\*** team index.

`CSWeaponData.AllowHandFlipping`
`CSWeaponData.ModelRightHanded`
`CSWeaponData.IsMeleeWeapon`

<h3>All new properties have been tested</h5>